### PR TITLE
Custom Zed Editor Settings for Streamlined, Minimal UI and Claude AI Integration

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,13 @@
+# Desktop Services Store, is an invisible file on the macOS operating system that gets automatically created anytime you look into a folder with ‘Finder.’
+.DS_Store
+
+# Local .terraform directories
+**/.terraform/*
+
+# .tfstate files
+*.tfstate
+*.tfstate.*
+
+# Terragrunt
+.terragrunt-cache
+.terraform.lock.hcl

--- a/dotfiles/keymap.json
+++ b/dotfiles/keymap.json
@@ -1,0 +1,21 @@
+// Zed keymap
+//
+// For information on binding keys, see the Zed
+// documentation: https://zed.dev/docs/key-bindings
+//
+// To see the default key bindings run `zed: open default keymap`
+// from the command palette.
+[
+  {
+    "context": "Workspace",
+    "bindings": {
+      // "shift shift": "file_finder::Toggle"
+    }
+  },
+  {
+    "context": "Editor",
+    "bindings": {
+      // "j k": ["workspace::SendKeystrokes", "escape"]
+    }
+  }
+]

--- a/dotfiles/settings.json
+++ b/dotfiles/settings.json
@@ -1,0 +1,56 @@
+// Zed settings
+//
+// For information on how to configure Zed, see the Zed
+// documentation: https://zed.dev/docs/configuring-zed
+//
+// To see all of Zed's default settings without changing your
+// custom settings, run `zed: open default settings` from the
+// command palette (cmd-shift-p / ctrl-shift-p)
+{
+  "agent": {
+    "default_model": {
+      "provider": "copilot_chat",
+      "model": "claude-3.7-sonnet-thought"
+    },
+    "version": "2"
+  },
+  "show_completions_on_input": false,
+  "inline_code_actions": false,
+  "project_panel": {
+    "dock": "left"
+  },
+  "toolbar": {
+    "breadcrumbs": true,
+    "quick_actions": false,
+    "selections_menu": false
+  },
+  "ui_font_family": "Monaspace Neon",
+  "buffer_font_family": "Monaspace Neon",
+  "features": {
+    "edit_prediction_provider": "zed",
+    "copilot": false
+  },
+  "show_edit_predictions": false,
+  "inlay_hints": {
+    "enabled": false
+  },
+  "theme": "Github Dark",
+  "telemetry": {
+    "metrics": false,
+    "diagnostics": false
+  },
+  "vim_mode": true,
+  "ui_font_size": 16,
+  "buffer_font_size": 14,
+  "cursor_blink": false,
+  "relative_line_numbers": false,
+  "tab_bar": {
+    "show": true
+  },
+  "scrollbar": {
+    "show": "never"
+  },
+  "preview_tabs": {
+    "enabled": false
+  }
+}


### PR DESCRIPTION
### **Motivation**
Personalized Zed settings.json configuration to improve the editing experience, minimize distractions, and integrate Claude AI as the default agent for chat-based assistance.

**AI Agent Configuration**
- Sets copilot_chat as the default provider
- Uses claude-3.7-sonnet-thought as the default model
- Disables GitHub Copilot

**UI and Layout Tweaks**
- Applies the "Github Dark" theme
- Uses Monaspace Neon as the UI and buffer font
- Sets font sizes: UI (16pt), Buffer (14pt)
- Disables cursor blinking
- Disables preview tabs and scrollbar
- Pins project panel to the left
- Enables tab bar display

**Editor Behavior**
- Disables inlay hints, edit predictions, inline code actions, and completion popups
- Enables Vim mode for modal editing
- Disables relative line numbers for simpler line display

**Toolbar Customization**
- Enables breadcrumbs
- Hides quick actions and selections menu

**Telemetry**
- Fully disables metrics and diagnostics reporting