### PR TITLE
Fix GitHub Dark theme name capitalisation

### DIFF
--- a/dotfiles/settings.json
+++ b/dotfiles/settings.json
@@ -42,7 +42,7 @@
   "inlay_hints": {
     "enabled": false
   },
-  "theme": "Github Dark",
+  "theme": "GitHub Dark",
   "telemetry": {
     "metrics": false,
     "diagnostics": false


### PR DESCRIPTION
## Summary

- Fixes `"Github Dark"` → `"GitHub Dark"` in `dotfiles/settings.json`

Zed theme names are case-sensitive. The incorrect capitalisation of the `H` meant the theme name didn't match the extension's registered name, so Zed silently fell back to the default theme.

🤖 Generated with [Claude Code](https://claude.com/claude-code)